### PR TITLE
fix stolen guesture bug

### DIFF
--- a/src/DrawerLayout.ios.js
+++ b/src/DrawerLayout.ios.js
@@ -95,7 +95,7 @@ export default class DrawerLayout extends React.Component {
       onMoveShouldSetPanResponder: this._shouldSetPanResponder,
       onPanResponderGrant: this._panResponderGrant,
       onPanResponderMove: this._panResponderMove,
-      onPanResponderTerminationRequest: () => true,
+      onPanResponderTerminationRequest: () => false,
       onPanResponderRelease: this._panResponderRelease,
       onPanResponderTerminate: () => { },
     });


### PR DESCRIPTION
This closes #3 hopefully. You can see an example on [exponent](https://getexponent.com/@danielmschmidt/drawerlayoutwip). @ericvicenti could you review this please?