### PR TITLE
Performance improvements.

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "autobind-decorator": "^1.3.2",
     "react-native-dismiss-keyboard": "1.0.0"
   },
   "devDependencies": {

--- a/src/DrawerLayout.js
+++ b/src/DrawerLayout.js
@@ -1,5 +1,4 @@
 import React, { Component, PropTypes } from 'react';
-import autobind from 'autobind-decorator';
 import dismissKeyboard from 'react-native-dismiss-keyboard';
 import {
   Animated,
@@ -164,20 +163,20 @@ export default class DrawerLayout extends Component {
     );
   }
 
-  @autobind _onOverlayClick(e) {
+  _onOverlayClick = (e) => {
     e.stopPropagation();
     if (!this._isLockedClosed() && !this._isLockedOpen()) {
       this.closeDrawer();
     }
   }
 
-  _emitStateChanged(newState) {
+  _emitStateChanged = (newState) => {
     if (this.props.onDrawerStateChanged) {
       this.props.onDrawerStateChanged(newState);
     }
   }
 
-  @autobind openDrawer(options = {}) {
+  openDrawer = (options = {}) => {
     this._emitStateChanged(SETTLING);
     Animated.spring(this.state.openValue, {
         toValue: 1,
@@ -193,7 +192,7 @@ export default class DrawerLayout extends Component {
       });
   }
 
-  @autobind closeDrawer(options = {}) {
+  closeDrawer = (options = {}) => {
     this._emitStateChanged(SETTLING);
     Animated.spring(this.state.openValue, {
         toValue: 0,
@@ -209,19 +208,19 @@ export default class DrawerLayout extends Component {
       });
   }
 
-  @autobind _handleDrawerOpen() {
+  _handleDrawerOpen = () => {
     if (this.props.onDrawerOpen) {
       this.props.onDrawerOpen();
     }
   }
 
-  @autobind _handleDrawerClose() {
+  _handleDrawerClose = () => {
     if (this.props.onDrawerClose) {
       this.props.onDrawerClose();
     }
   }
 
-  @autobind _shouldSetPanResponder(e, { moveX, dx, dy }) {
+  _shouldSetPanResponder = (e, { moveX, dx, dy }) => {
     const { drawerPosition } = this.props;
 
     if (this._isLockedClosed() || this._isLockedOpen()) {
@@ -270,11 +269,11 @@ export default class DrawerLayout extends Component {
     }
   }
 
-  @autobind _panResponderGrant() {
+  _panResponderGrant = () => {
     this._emitStateChanged(DRAGGING);
   }
 
-  @autobind _panResponderMove(e, { moveX }) {
+  _panResponderMove = (e, { moveX }) => {
     let openValue = this._getOpenValueForX(moveX);
 
     if (this._isClosing) {
@@ -290,7 +289,7 @@ export default class DrawerLayout extends Component {
     this.state.openValue.setValue(openValue);
   }
 
-  @autobind _panResponderRelease(e, { moveX, vx }) {
+  _panResponderRelease = (e, { moveX, vx }) => {
     const { drawerPosition } = this.props;
     const previouslyOpen = this._isClosing;
     const isWithinVelocityThreshold = vx < VX_MAX && vx > -VX_MAX;
@@ -336,17 +335,17 @@ export default class DrawerLayout extends Component {
     }
   }
 
-  _isLockedClosed() {
+  _isLockedClosed = () => {
     return this.props.drawerLockMode === 'locked-closed' &&
       !this.state.drawerShown;
   }
 
-  _isLockedOpen() {
+  _isLockedOpen = () => {
     return this.props.drawerLockMode === 'locked-open' &&
       this.state.drawerShown;
   }
 
-  _getOpenValueForX(x) {
+  _getOpenValueForX = (x) => {
     const { drawerPosition, drawerWidth } = this.props;
 
     if (drawerPosition === 'left') {

--- a/src/DrawerLayout.js
+++ b/src/DrawerLayout.js
@@ -221,6 +221,10 @@ export default class DrawerLayout extends Component {
   }
 
   _shouldSetPanResponder = (e, { moveX, dx, dy }) => {
+    if (!dx || !dy) {
+      return false;
+    }
+
     const { drawerPosition } = this.props;
 
     if (this._isLockedClosed() || this._isLockedOpen()) {

--- a/src/DrawerLayout.js
+++ b/src/DrawerLayout.js
@@ -22,6 +22,7 @@ export default class DrawerLayout extends Component {
   static defaultProps = {
     drawerWidth: 0,
     drawerPosition: 'left',
+    useNativeAnimations: false
   };
 
   static positions = {
@@ -46,6 +47,7 @@ export default class DrawerLayout extends Component {
     onDrawerStateChanged: PropTypes.func,
     renderNavigationView: PropTypes.func.isRequired,
     statusBarBackgroundColor: PropTypes.string,
+    useNativeAnimations: PropTypes.bool
   };
 
   constructor(props, context) {
@@ -140,7 +142,8 @@ export default class DrawerLayout extends Component {
       extrapolate: 'clamp',
     });
     const animatedOverlayStyles = { opacity: overlayOpacity };
-
+    const pointerEvents = drawerShown ? 'auto' : 'none';
+    
     return (
       <View
         style={{ flex: 1, backgroundColor: 'transparent' }}
@@ -149,11 +152,9 @@ export default class DrawerLayout extends Component {
         <Animated.View style={styles.main}>
           {this.props.children}
         </Animated.View>
-
-        {drawerShown &&
-          <TouchableWithoutFeedback onPress={this._onOverlayClick}>
-            <Animated.View style={[styles.overlay, animatedOverlayStyles]} />
-          </TouchableWithoutFeedback>}
+        <TouchableWithoutFeedback pointerEvents={pointerEvents} onPress={this._onOverlayClick}>
+          <Animated.View pointerEvents={pointerEvents} style={[styles.overlay, animatedOverlayStyles]} />
+        </TouchableWithoutFeedback>
         <Animated.View
           style={[styles.drawer, dynamicDrawerStyles, animatedDrawerStyles]}
         >
@@ -182,6 +183,7 @@ export default class DrawerLayout extends Component {
         toValue: 1,
         bounciness: 0,
         restSpeedThreshold: 0.1,
+        useNativeDriver: this.props.useNativeAnimations,
         ...options,
       })
       .start(() => {
@@ -198,6 +200,7 @@ export default class DrawerLayout extends Component {
         toValue: 0,
         bounciness: 0,
         restSpeedThreshold: 1,
+        useNativeDriver: this.props.useNativeAnimations,
         ...options,
       })
       .start(() => {


### PR DESCRIPTION
**Removed autobind decorator:**
The form that I have put in works instead of using an autobind decorator.
#14 

**Drawer not closing on 3d touch:**
This has been tested on a 3d touch device and works.
#10

**Add ability to use native animations:**
Significant performance improvements for Android. Off by default, set useNativeAnimations property to turn it on.
#9 

**Changed how overlay draws:**
Makes the overlay not dependent on JS thread so you don't get a pop in when animating.
#15 