### PR TITLE
Fixed: works correctly with RTL languages (e.g. Hebrew/Arabic)

### DIFF
--- a/src/DrawerLayout.js
+++ b/src/DrawerLayout.js
@@ -92,8 +92,6 @@ export default class DrawerLayout extends Component {
 
     this._isRTL = I18nManager.isRTL;
 
-    console.log(`Is RTL ${this._isRTL ? 'yes' : 'no'}`);
-
     openValue.addListener(({ value }) => {
       const drawerShown = value > 0;
       if (drawerShown !== this.state.drawerShown) {

--- a/src/DrawerLayout.js
+++ b/src/DrawerLayout.js
@@ -8,6 +8,7 @@ import {
   StyleSheet,
   TouchableWithoutFeedback,
   View,
+  I18nManager,
 } from 'react-native';
 
 const MIN_SWIPE_DISTANCE = 3;
@@ -64,6 +65,7 @@ export default class DrawerLayout extends Component {
   _panResponder: any;
   _isClosing: boolean;
   _closingAnchorValue: number;
+  _isRTL: boolean;
 
   static defaultProps = {
     drawerWidth: 0,
@@ -87,6 +89,10 @@ export default class DrawerLayout extends Component {
 
   componentWillMount() {
     const { openValue } = this.state;
+
+    this._isRTL = I18nManager.isRTL;
+
+    console.log(`Is RTL ${this._isRTL ? 'yes' : 'no'}`);
 
     openValue.addListener(({ value }) => {
       const drawerShown = value > 0;
@@ -137,9 +143,9 @@ export default class DrawerLayout extends Component {
     let outputRange;
 
     if (drawerPosition === 'left') {
-      outputRange = [-drawerWidth, 0];
+      outputRange = this._isRTL ? [drawerWidth, 0] : [-drawerWidth, 0];
     } else {
-      outputRange = [drawerWidth, 0];
+      outputRange = this._isRTL ? [-drawerWidth, 0] : [drawerWidth, 0];
     }
 
     const drawerTranslateX = openValue.interpolate({


### PR DESCRIPTION
I have fixed an incorrect behavior when react-native is in RTL mode (the interface language is written from right to left, e.g. Hebrew/Arabic).

 To easiest way to force react-native into RTL is to put in your index.ios.js file the following:

import {I18nManager} from 'react-native';

I18nManager.forceRTL(true)

This will force react-native into RTL mode even if your language is not RTL. You can see that the drawer will be opened from the right side rather than the left.

 If you try it with the original version, you will see that the drawer is rendered in incorrect location since the x translation is incorrect.

