### PR TITLE
Fix gesture direction in RTL layout

### DIFF
--- a/src/DrawerLayout.js
+++ b/src/DrawerLayout.js
@@ -145,9 +145,13 @@ export default class DrawerLayout extends Component {
     let outputRange;
 
     if (drawerPosition === 'left') {
-      outputRange = this._isRTL ? [drawerWidth, 0] : [-drawerWidth, 0];
+      outputRange = this._isRTL
+        ? [-DEVICE_WIDTH, -DEVICE_WIDTH + drawerWidth]
+        : [-drawerWidth, 0];
     } else {
-      outputRange = this._isRTL ? [-drawerWidth, 0] : [drawerWidth, 0];
+      outputRange = this._isRTL
+        ? [DEVICE_WIDTH + drawerWidth, DEVICE_WIDTH - drawerWidth]
+        : [drawerWidth, 0];
     }
 
     const drawerTranslateX = openValue.interpolate({

--- a/src/DrawerLayout.js
+++ b/src/DrawerLayout.js
@@ -39,7 +39,6 @@ export type StateType = {
   drawerShown: boolean,
   openValue: any,
   windowWidth: number,
-  threshold: number,
 };
 
 export type EventType = {
@@ -95,7 +94,6 @@ export default class DrawerLayout extends Component {
       drawerShown: false,
       openValue: new Animated.Value(0),
       windowWidth,
-      threshold: windowWidth / 2,
     };
   }
 
@@ -140,7 +138,6 @@ export default class DrawerLayout extends Component {
   _handleOrientationChange = (dimension: DimensionsEventType) => {
     this.setState({
       windowWidth: dimension.window.width,
-      threshold: dimension.window.width / 2,
     });
   };
 
@@ -363,7 +360,7 @@ export default class DrawerLayout extends Component {
     { moveX, vx }: PanResponderEventType,
   ) => {
     const { drawerPosition } = this.props;
-    const { threshold } = this.state;
+    const threshold = this.state.windowWidth / 2;
     const previouslyOpen = this._isClosing;
     const isWithinVelocityThreshold = vx < VX_MAX && vx > -VX_MAX;
 


### PR DESCRIPTION
The gesture direction(only in RTL Layout) is always from left to right and it doesn't follow the `drawerPosition` 

**My solution:**
*(It's not the best solution, but it works great – I was unable to change the panResponder events to support both directions)*
I calculate the `outputRange` values using window width and `drawerWidth` and because of that I had to add `Dimensions.addEventListener(...)` to listen to the orientation changes.

I tested this on both Android and iOS

\* `Dimensions.addEventListener` only works on `react-native@>=0.43.0`