### PR TITLE
Opacity 0 when not shown

### DIFF
--- a/src/DrawerLayout.js
+++ b/src/DrawerLayout.js
@@ -196,6 +196,7 @@ export default class DrawerLayout extends Component {
                         styles.drawer,
                         dynamicDrawerStyles,
                         animatedDrawerStyles,
+                        { opacity: drawerShown ? 1 : 0 },
                     ]}
                 >
                     {this.props.renderNavigationView()}


### PR DESCRIPTION
Fixes #50 
Tested on this [snack](https://snack.expo.io/@kriskate/ios-drawer-disabled-swipe-to-back)