### PR TITLE
Add drawerSlideTargetWidth

### DIFF
--- a/src/DrawerLayout.js
+++ b/src/DrawerLayout.js
@@ -25,6 +25,7 @@ export type PropType = {
     drawerBackgroundColor?: string,
     drawerLockMode?: 'unlocked' | 'locked-closed' | 'locked-open',
     drawerPosition: 'left' | 'right',
+    drawerSlideTargetWidth: number,
     drawerWidth: number,
     keyboardDismissMode?: 'none' | 'on-drag',
     onDrawerClose?: Function,
@@ -70,6 +71,7 @@ export default class DrawerLayout extends Component {
     static defaultProps = {
         drawerWidth: 0,
         drawerPosition: 'left',
+        drawerSlideTargetWidth: 35,
         useNativeAnimations: false,
     };
 
@@ -287,7 +289,7 @@ export default class DrawerLayout extends Component {
                     return true;
                 }
             } else {
-                if (moveX <= 35 && dx > 0) {
+                if (moveX <= this.props.drawerSlideTargetWidth && dx > 0) {
                     this._isClosing = false;
                     return true;
                 }
@@ -307,7 +309,9 @@ export default class DrawerLayout extends Component {
                     return true;
                 }
             } else {
-                if (moveX >= DEVICE_WIDTH - 35 && dx < 0) {
+                if (
+                  moveX >= DEVICE_WIDTH - this.props.drawerSlideTargetWidth && dx < 0
+                ) {
                     this._isClosing = false;
                     return true;
                 }


### PR DESCRIPTION
Fix #33

Instead of hard coding a target width of 35 to grab the drawer and slide it, allow the user to specify the width they want to set that to. Works greate with `deviceWidth/2`

We can totally change `drawerSlideTargetWidth` to something else, I'm not sure what this would be called generally. This just made the most sense at the time.
