### PR TITLE
Update outdated lifecycle methods

### DIFF
--- a/src/DrawerLayout.js
+++ b/src/DrawerLayout.js
@@ -96,7 +96,7 @@ export default class DrawerLayout extends Component {
             : drawerPosition;
     }
 
-    componentWillMount() {
+    componentDidMount() {
         const { openValue } = this.state;
 
         openValue.addListener(({ value }) => {

--- a/src/DrawerLayout.js
+++ b/src/DrawerLayout.js
@@ -80,7 +80,14 @@ export default class DrawerLayout extends Component {
 
     constructor(props: PropType, context: any) {
         super(props, context);
-
+        this._panResponder = PanResponder.create({
+          onMoveShouldSetPanResponder: this._shouldSetPanResponder,
+          onPanResponderGrant: this._panResponderGrant,
+          onPanResponderMove: this._panResponderMove,
+          onPanResponderTerminationRequest: () => false,
+          onPanResponderRelease: this._panResponderRelease,
+          onPanResponderTerminate: () => {},
+      });
         this.state = {
             accessibilityViewIsModal: false,
             drawerShown: false,
@@ -116,14 +123,6 @@ export default class DrawerLayout extends Component {
             }
         });
 
-        this._panResponder = PanResponder.create({
-            onMoveShouldSetPanResponder: this._shouldSetPanResponder,
-            onPanResponderGrant: this._panResponderGrant,
-            onPanResponderMove: this._panResponderMove,
-            onPanResponderTerminationRequest: () => false,
-            onPanResponderRelease: this._panResponderRelease,
-            onPanResponderTerminate: () => {},
-        });
     }
 
     render() {


### PR DESCRIPTION
# Summary

Resolves #51 

React-native-router-flux uses this repo as a dependency. This repo is throwing a yellow warning due to the use of componentWillMount. This change solves that issue.

I moved the panResponder to the constructor per the RN docs. I then updated componentWillMount to componentDidMount.

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
